### PR TITLE
修改 hyperref 设置、修改助教姓名、修改字体

### DIFF
--- a/lecture01/slide.tex
+++ b/lecture01/slide.tex
@@ -15,7 +15,7 @@
 %	PACKAGES AND THEMES
 %----------------------------------------------------------------------------------------
 
-\documentclass[UTF8]{ctexbeamer}
+\documentclass[UTF8,hyperref={colorlinks=true,linkcolor=red,anchorcolor=blue,citecolor=green}]{ctexbeamer}
 
 \mode<presentation> {
 
@@ -78,7 +78,7 @@
 
 \usepackage{graphicx} % Allows including images
 \usepackage{booktabs} % Allows the use of \toprule, \midrule and \bottomrule in tables
-\usepackage[colorlinks,linkcolor=red,anchorcolor=blue,citecolor=green]{hyperref}
+
 %----------------------------------------------------------------------------------------
 %	TITLE PAGE
 %----------------------------------------------------------------------------------------
@@ -293,4 +293,4 @@ This statement requires citation \cite{p1}.
 
 %----------------------------------------------------------------------------------------
 
-\end{document} 
+\end{document}

--- a/lecture01/slide.tex
+++ b/lecture01/slide.tex
@@ -15,7 +15,15 @@
 %	PACKAGES AND THEMES
 %----------------------------------------------------------------------------------------
 
-\documentclass[UTF8,hyperref={colorlinks=true,linkcolor=red,anchorcolor=blue,citecolor=green}]{ctexbeamer}
+\documentclass[UTF8]{ctexbeamer}
+
+\usepackage{hyperref}
+\hypersetup{
+  colorlinks=true,
+  linkcolor=red,
+  anchorcolor=blue,
+  citecolor=green
+}
 
 \mode<presentation> {
 
@@ -79,6 +87,11 @@
 \usepackage{graphicx} % Allows including images
 \usepackage{booktabs} % Allows the use of \toprule, \midrule and \bottomrule in tables
 
+% Fonts
+% \usepackage{libertine}
+% \setmonofont{Courier}
+\setCJKsansfont[ItalicFont=Noto Serif CJK SC Black, BoldFont=Noto Sans CJK SC Black]{Noto Sans CJK SC}
+
 %----------------------------------------------------------------------------------------
 %	TITLE PAGE
 %----------------------------------------------------------------------------------------
@@ -133,9 +146,9 @@
 \begin{frame}
 	\frametitle{课程信息}
 	\begin{itemize}
-		\item 主讲教师：向勇 陈渝
-		\item 助教: 王润基 贾越凯 戴臻杨 刘丰源 
-		\item 助教: 吴一凡 潘庆霖 张译仁 陈嘉杰
+		\item 主讲教师：向勇、陈渝
+		\item 助教: 王润基、贾越凯、戴臻旸、刘丰源
+		\item 助教: 吴一凡、潘庆霖、张译仁、陈嘉杰
 	\end{itemize}
 \end{frame}
 
@@ -145,7 +158,7 @@
 	\begin{itemize}
 		\item \href{http://os.cs.tsinghua.edu.cn/oscourse/OS2018spring}{\textbf{WIKI}}
 		\item 学堂在线
-		\item 网络学堂 
+		\item 网络学堂
 		\item 微信：OS课2O2O
 		\item 实验楼在线实验环境
 	\end{itemize}


### PR DESCRIPTION
ubuntu 下 旸 字不改字体无法显示，所以需要修改字体。

noto 字体许可证是 SIL Open Font License 1.1，没有问题

如果找不到字体，检查

fonts-noto-cjk
fonts-noto-cjk-extra
fonts-noto-mono

包是否通过 apt 安装